### PR TITLE
Add support for managing a .onion from the bastion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_install:
 install:
   - pip install ansible-lint
   - pip install flake8
+  - ( cd .. ; git clone https://gitlab.com/osas/ansible-role-tor.git tor)
 script:
 # verify the syntax of the playbook
   - set -e ; for i in tasks/*.yml; do ansible-lint $i; done

--- a/README.md
+++ b/README.md
@@ -106,3 +106,30 @@ the option `ssh_key_type` to use a different type of key.
 
 This however requires a bugfix on ansible for the automated size selection of the key,
 sent as a PR on https://github.com/ansible/ansible-modules-core/pull/4074
+
+Management of tor hidden services
+---------------------------------
+
+Since ansible is using ssh and ssh can be used with tor hidden services, you can
+choose to enable the support for tor hidden services by using the `enable_onion_support`
+option like this:
+
+```
+- hosts: bastion.example.org
+  roles:
+  - role: bastion
+    enable_onion_support: True
+```
+
+It will configure tor and ssh to use tor for accessing a .onion hostname.
+
+It can be used like this in hosts file, to connect to a server whose hidden service
+is abcdefabcdef.onion:
+
+```
+[all]
+server ansible_host=abcdefabcdef.onion
+
+[web]
+server
+```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,3 +27,5 @@ pusher_username: _git_pusher
 allow_ansible_commands: False
 # permit to use a specific type of key
 ssh_key_type: rsa
+# add support for accessing .onion
+enable_onion_support: False

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,9 +16,6 @@ galaxy_info:
     - 7
   categories:
   - system
-dependencies: []
-  # List your role dependencies here, one per line. Only
-  # dependencies available via galaxy should be listed here.
-  # Be sure to remove the '[]' above if you add dependencies
-  # to this list.
-  
+dependencies:
+  - role: tor
+    when: enable_onion_support

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,12 @@
     name: git
     state: present
 
+- name: Install socat
+  package:
+    name: socat
+    state: present
+  when: enable_onion_support
+
 - name: Create ansible user {{ ansible_username }}
   user:
     name: "{{ ansible_username }}"

--- a/templates/ssh_config
+++ b/templates/ssh_config
@@ -1,3 +1,8 @@
 # {{ ansible_managed }}
 Host *.{{ ansible_domain }}
     GSSAPIDelegateCredentials yes
+
+{% if enable_onion_support %}
+Host *.onion
+    ProxyCommand socat - SOCKS4A:localhost:%h:%p,socksport=9050
+{% endif %}


### PR DESCRIPTION
This just enable the ssh configuration to go on the tor network
for hosts that can only be reached by that. This permit to close
the port 22 on the server, since it can be reached only with tor
and by someone knowing the name.
