### PR TITLE
Add a script to prevent pushing a branch

### DIFF
--- a/tasks/pre_receive_checks.yml
+++ b/tasks/pre_receive_checks.yml
@@ -1,6 +1,9 @@
 ---
-- name: Deploy the gitignore check
+- name: Deploy the pre-receive check
   template:
-    dest: "{{ git_repositories_dir }}/public/hooks/pre-receive.d/01_check_git_ignore.py"
-    src: hooks/check_git_ignore.py
+    dest: "{{ git_repositories_dir }}/public/hooks/pre-receive.d/{{ item.order}}_{{ item.script }}"
+    src: hooks/{{ item.script }}
     mode: 0755
+  with_items:
+  - { order: '01', script: check_git_ignore.py }
+  - { order: '02', script: check_branch_master.py }

--- a/templates/hooks/check_branch_master.py
+++ b/templates/hooks/check_branch_master.py
@@ -1,0 +1,35 @@
+#!/usr/bin/python
+#
+# {{ ansible_managed }}
+#
+#
+# Copyright (c) 2016 Michael Scherer <mscherer@redhat.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+#
+# This script prevent pushing on anything but master.
+#
+
+import sys
+
+for l in sys.stdin.readlines():
+    if l.split()[2] != 'refs/heads/master':
+        print "Push on another branch than master is not authorized"
+        sys.exit(1)


### PR DESCRIPTION
As I start to use branch for work in progress, I found myself
pushing a non-master branch too often, with unexpected
result (like, redeploy the whole infra, which take a
ton of time).
