### PR TITLE
Fix the code to correspond to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,17 @@ repository need to follow a few set of rules:
  - all playbooks are in playbooks/ and the one to be used for automated deployment
    are named with this pattern: deploy.\*.yml
 
+Using git snapshot of Ansible
+-----------------------------
+
+The role can also be used to install ansible right from git, using the HEAD of the
+devel branch by default.
+
+To do that, you can use the `use_ansible_git` flag, along `ansible_git_version` if
+you want a different branch and/or version of ansible than the default of 'devel'. This
+variable is passed to the 'git' ansible module, so it accept everything the module
+accept.
+
 Groups based ACL
 ----------------
 

--- a/tasks/install_ansible_git.yml
+++ b/tasks/install_ansible_git.yml
@@ -16,6 +16,7 @@
   git:
     repo: "https://github.com/ansible/ansible.git"
     dest: "{{ checkout_dir }}"
+    version: "{{ ansible_git_version }}"
 
 - name: Create helper scripts
   template:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,10 +16,10 @@
   when: ansible_admin_group is defined
 
 - include: install_ansible_rpm.yml
-  when: use_ansible_HEAD is not defined
+  when: not use_ansible_git
 
 - include: install_ansible_git.yml
-  when: use_ansible_HEAD is defined
+  when: use_ansible_git
 
 - name: Setup ssh config for {{ ansible_username }}
   template:


### PR DESCRIPTION
There was a option called use_ansible_HEAD that
was never documented and instead the documented one
was never completed fully. This bring the 2 of them
in sync.
