### PR TITLE
Add python-netaddr to use ipaddr jinja filter

### DIFF
--- a/tasks/install_ansible_git.yml
+++ b/tasks/install_ansible_git.yml
@@ -11,6 +11,7 @@
   - python-httplib2
   - PyYAML
   - python-keyczar
+  - python-netaddr
 
 - name: Checkout git in {{ checkout_dir }}
   git:

--- a/tasks/install_ansible_rpm.yml
+++ b/tasks/install_ansible_rpm.yml
@@ -4,3 +4,4 @@
     state: present
   with_items:
   - ansible
+  - python-netaddr


### PR DESCRIPTION
Since some role are starting soon to use that filter it need
to be installed on the bastion.
