### PR TITLE
Add configuration to direct git in tor

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -122,3 +122,6 @@
 
 - include: push_remote.yml
   when: remotes is defined
+
+- include: use_tor_proxy.yml
+  when: use_tor_proxy

--- a/tasks/use_tor_proxy.yml
+++ b/tasks/use_tor_proxy.yml
@@ -1,0 +1,8 @@
+- name: Set proxy config to use tor
+  git_config:
+    scope: "global"
+    name: "{{ item }}.proxy"
+    value: "socks5h://127.0.0.1:9050"
+  with_items:
+  - http
+  - https


### PR DESCRIPTION
This is required to avoid DNS leak and connecting to
github/gitlab without using tor, as this would break
anonimity.
