### PR TITLE
Fix errors when run without sudo

### DIFF
--- a/files/generate_ansible_command.py
+++ b/files/generate_ansible_command.py
@@ -79,7 +79,7 @@ if 'SUDO_USER' in os.environ:
         ' '.join(sys.argv)))
 else:
     syslog.syslog("Direct execution with args: {}".format(
-        ' '.join(sys.argv())))
+        ' '.join(sys.argv)))
 
 
 def load_config(config_file):


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/local/bin/generate_ansible_command.py", line 82, in <module>
    ' '.join(sys.argv())))
TypeError: 'list' object is not callable
```
