### PR TITLE
Add support for ansible_ssh_host

### DIFF
--- a/files/bastion_lib.py
+++ b/files/bastion_lib.py
@@ -81,9 +81,9 @@ def extract_list_hosts_git(revision, path):
     for group in inventory.get_groups():
         for host in inventory.get_hosts(group):
             vars_host = variable_manager.get_vars(loader, host=host)
-            result.append({'name': host.name,
-                           'connection': vars_host.get('ansible_connection',
-                                                       'ssh')})
+            result.append(
+                {'name': vars_host.get('ansible_ssh_host', host.name),
+                 'connection': vars_host.get('ansible_connection', 'ssh')})
 
     # for some reason, there is some kind of global cache that need to be
     # cleaned


### PR DESCRIPTION
With the use of onion services, we have to use hosts files
like this:

```
[tor_relay]
relay_1 ansible_ssh_host=exampleexample.onion
```

So in order to make the automated ssh keys discovery work, we need
to use the ansible_hostname if set, not the name.
