### PR TITLE
Disable retry files

### DIFF
--- a/templates/ansible.cfg
+++ b/templates/ansible.cfg
@@ -30,6 +30,7 @@ remote_port    = 22
 module_lang    = C
 
 force_color    = True
+retry_files_enabled = False
 
 stdout_callback = actionable
 


### PR DESCRIPTION
On the bastion, since the playbooks are run out of /etc, ansible
do not write it at the right place and they are unlikely to
be used in the context of the bastion.
