### PR TITLE
Fix simultaneous use of enable_onion_support and use_tor_proxy

### DIFF
--- a/templates/ssh_config
+++ b/templates/ssh_config
@@ -3,10 +3,10 @@ Host *.{{ ansible_domain }}
     GSSAPIDelegateCredentials yes
 
 {% if enable_onion_support or use_tor_proxy %}
-{% if enable_onion_support %}
-Host *.onion
-{% else %}
+{% if use_tor_proxy %}
 Host *
+{% else %}
+Host *.onion
 {% endif %}
     ProxyCommand socat - SOCKS4A:localhost:%h:%p,socksport=9050
 {% endif %}


### PR DESCRIPTION
If a user do set enable_onion_support, and then switch to
use_tor_proxy: True, the config file will not change, due
to the conditional used.
