### PR TITLE
Increase the timeout if we use tor to make connexion

### DIFF
--- a/templates/ansible.cfg
+++ b/templates/ansible.cfg
@@ -54,7 +54,7 @@ sudo_exe = sudo
 #sudo_flags = -H
 
 # SSH timeout
-timeout = 10
+timeout = {% if enable_onion_support or use_tor_proxy %}40{% else %}10{% endif %}
 
 # default user to use for playbooks if user is not specified
 # (/usr/bin/ansible will use current user as default)


### PR DESCRIPTION
As I found out experimentally, it take sometime a long time to connect over tor to a hidden service, or a regular server. So i bumped to 40, a arbitrary number, for that specific case.
