### PR TITLE
Do not define ANSIBLE_COMMAND if we not use later

### DIFF
--- a/templates/cmd_config.sudoers
+++ b/templates/cmd_config.sudoers
@@ -2,7 +2,9 @@
 
 Cmnd_Alias UPDATE_ANSIBLE_CONFIG = /usr/local/bin/update_ansible_config.sh
 Cmnd_Alias GENERATE_ANSIBLE_COMMAND = /usr/local/bin/generate_ansible_command.py
+{% if allow_ansible_commands %}
 Cmnd_Alias ANSIBLE_COMMAND = /usr/bin/ansible,/usr/bin/ansible-playbook
+{% endif %}
 Cmnd_Alias UPDATE_EXTERNAL_ROLES = /usr/local/bin/update_galaxy.sh
 
 Defaults!UPDATE_ANSIBLE_CONFIG    !requiretty


### PR DESCRIPTION
sudo do complain a bit on Fedora, and I think that's better to be
warning-free
