### PR TITLE
Replace the ansible_admin group by a committers group

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,21 +93,39 @@ In order to ease collaboration and increase security, the repositories can be co
 to be writable by a specific group, with proper sudo configuration that avoid the need to use
 root user.
 
-To enable this mode, you need to define the `ansible_admin_group` variable like this:
+To enable this mode, you need to define the `ansible_commiters_group` variable like this:
 
 ```
 - hosts: bastion.example.org
   roles:
   - role: bastion
-    ansible_admin_group: admins
+    ansible_committers_group: committers
 ```
 
 The group will be created if it doesn't already exist.
 
-By default, admins can only push and trigger the hooks, but you can also enable them
-to run various ansible command with the `allow_ansible_commands` variable. Be aware that
-this is equivalent of giving them root access, since they can them do modification outside
-of the git repository.
+By default, committers can only push and trigger the hooks, and this mean everything
+they do will be properly audited in git, and run with verification.
+
+If you want to be able to do more, you can also create a group for admins who will have
+more privileges such as running variables ansible commands, which would be equivalent to becoming
+root.
+
+To do that, you can use the `ansible_admins_group` variables like this:
+
+```
+- hosts: bastion.example.org
+  roles:
+  - role: bastion
+    ansible_committers_group: committers
+    ansible_admins_group: admins
+```
+
+Like with `ansible_committers_group`, the group will be created if it doesn't exist. Due
+to the way group are currently done on Linux, people in the `ansible_admins_group` do
+not automatically inherit the access of `ansible_committers_group` for the moment.
+
+The role will refuse to deploy anything if only `ansible_admins_group` is defined.
 
 SSH Key type
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,8 +23,6 @@ ansible_git_version: devel
 git_username: git
 # the username that will run the sync script that push to a remote repo
 pusher_username: _git_pusher
-# permit admin to run ansible command from sudo
-allow_ansible_commands: False
 # permit to use a specific type of key
 ssh_key_type: rsa
 # add support for accessing .onion

--- a/tasks/compat_ansible_admin_group.yml
+++ b/tasks/compat_ansible_admin_group.yml
@@ -1,0 +1,7 @@
+- name: Display message about deprecated variable
+  pause:
+    seconds: 30
+    prompt: "The variable ansible_admin_group is deprecated, please convert to ansible_committers_group"
+
+- set_fact:
+    ansible_committers_group: "{{ ansible_admin_group }}"

--- a/tasks/create_repo.yml
+++ b/tasks/create_repo.yml
@@ -3,7 +3,7 @@
   file:
     path: "{{ git_repositories_dir }}/{{ repo }}"
     state: directory
-    group: "{{ ansible_admin_group | default(omit) }}"
+    group: "{{ ansible_committers_group | default(omit) }}"
     mode: "u=rwx,g=rwxs"
 
 - name: Initialize the {{ repo }} git repos

--- a/tasks/git_shell.yml
+++ b/tasks/git_shell.yml
@@ -6,7 +6,7 @@
     name: "{{ git_username }}"
     shell: /usr/bin/git-shell
     home: "{{ git_home }}"
-    group: "{{ ansible_admin_group | default(omit) }}"
+    group: "{{ ansible_committers_group | default(omit) }}"
 
 - name: Create git-shell-commands directory
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,17 @@
 ---
+- include: compat_ansible_admin_group.yml
+  when: ansible_admin_group is defined
+
+- name: Verify that the groups are all defined
+  fail:
+    msg: "ansible_admins_group is defined while ansible_committers_group is not"
+  when: ansible_admins_group is defined and ansible_committers_group is undefined
+
+- name: Fail is old option are used
+  fail:
+    msg: "allow_ansible_commands is deprecated, please see ansible_admins_group in README.md"
+  when: allow_ansible_commands is defined
+
 - name: Install tools
   package:
     name: "{{ item }}"
@@ -19,10 +32,15 @@
     generate_ssh_key: yes
     ssh_key_type: "{{ ssh_key_type }}"
 
-- name: Create {{ ansible_admin_group }} group
+- name: Create {{ ansible_admins_group }} group
   group:
-    name: "{{ ansible_admin_group }}"
-  when: ansible_admin_group is defined
+    name: "{{ ansible_admins_group }}"
+  when: ansible_admins_group is defined
+
+- name: Create {{ ansible_committers_group }} group
+  group:
+    name: "{{ ansible_committers_group }}"
+  when: ansible_committers_group is defined
 
 - include: install_ansible_rpm.yml
   when: not use_ansible_git
@@ -50,10 +68,10 @@
 
 - name: Add sudo config for admins
   template:
-    dest: "/etc/sudoers.d/{{ ansible_admin_group }}_cmd_config"
+    dest: "/etc/sudoers.d/{{ ansible_committers_group }}_cmd_config"
     src: cmd_config.sudoers
     validate: 'visudo -cf %s'
-  when: ansible_admin_group is defined
+  when: ansible_committers_group is defined
 
 - include: create_repos.yml
 

--- a/tasks/push_remote.yml
+++ b/tasks/push_remote.yml
@@ -35,4 +35,4 @@
     dest: /etc/sudoers.d/push_remote_public
     src: push_remote_public.sudoers
     validate: 'visudo -cf %s'
-  when: ansible_admin_group is defined
+  when: ansible_committers_group is defined

--- a/templates/cmd_config.sudoers
+++ b/templates/cmd_config.sudoers
@@ -1,15 +1,17 @@
 # {{ ansible_managed }}
 
-Cmnd_Alias UPDATE_ANSIBLE_CONFIG = /usr/local/bin/update_ansible_config.sh
-Cmnd_Alias GENERATE_ANSIBLE_COMMAND = /usr/local/bin/generate_ansible_command.py
-Cmnd_Alias ANSIBLE_COMMAND = /usr/bin/ansible,/usr/bin/ansible-playbook
 Cmnd_Alias UPDATE_EXTERNAL_ROLES = /usr/local/bin/update_galaxy.sh
 
+Cmnd_Alias UPDATE_ANSIBLE_CONFIG = /usr/local/bin/update_ansible_config.sh
 Defaults!UPDATE_ANSIBLE_CONFIG    !requiretty
+
+Cmnd_Alias GENERATE_ANSIBLE_COMMAND = /usr/local/bin/generate_ansible_command.py
 Defaults!GENERATE_ANSIBLE_COMMAND !requiretty
 
-%{{ ansible_admin_group }}  ALL=(root) NOPASSWD: UPDATE_ANSIBLE_CONFIG, UPDATE_EXTERNAL_ROLES
-%{{ ansible_admin_group }}  ALL=({{ ansible_username }}) NOPASSWD: GENERATE_ANSIBLE_COMMAND
-{% if allow_ansible_commands %}
-%{{ ansible_admin_group }}  ALL=({{ ansible_username }}) ANSIBLE_COMMAND
+%{{ ansible_committers_group }}  ALL=(root) NOPASSWD: UPDATE_ANSIBLE_CONFIG, UPDATE_EXTERNAL_ROLES
+%{{ ansible_committers_group }}  ALL=({{ ansible_username }}) NOPASSWD: GENERATE_ANSIBLE_COMMAND
+
+{% if ansible_admins_group %}
+Cmnd_Alias ANSIBLE_COMMAND = /usr/bin/ansible,/usr/bin/ansible-playbook
+%{{ ansible_admins_group }}  ALL=({{ ansible_username }}) NOPASSWD: ANSIBLE_COMMAND
 {% endif %}

--- a/templates/push_remote_public.sudoers
+++ b/templates/push_remote_public.sudoers
@@ -4,4 +4,4 @@ Cmnd_Alias PUSH_REMOTE_PUBLIC = /usr/local/bin/push_remote_public.sh
 
 Defaults!PUSH_REMOTE_PUBLIC  !requiretty
 
-%{{ ansible_admin_group }}  ALL=({{ pusher_username }}) NOPASSWD: PUSH_REMOTE_PUBLIC
+%{{ ansible_committers_group }}  ALL=({{ pusher_username }}) NOPASSWD: PUSH_REMOTE_PUBLIC


### PR DESCRIPTION
This also deprecated the allow_ansible_commands, and replace it
with a group based access. The main driver of the change is to
be able to use gerrit for doing code review, and so be able
to give more privileges to humans admins (such as me) than
to a potential gerrit bot account that would be only able
to push and not run anything else. The idea being that in
case a of a gerrit compromision, the attacker will not be
able to do anything that would end unaudited (such as running
a custom ansible script).

This also clarify exactly the level of access given to each users,
and provide a 2 tier ACL system permitting to ease integration
of new comers.
