### PR TITLE
Remove the ansible package on bastion

### DIFF
--- a/tasks/install_ansible_git.yml
+++ b/tasks/install_ansible_git.yml
@@ -13,6 +13,11 @@
   - python-keyczar
   - python-netaddr
 
+- name: Remove ansible package
+  package:
+    name: ansible
+    state: absent
+
 - name: Checkout git in {{ checkout_dir }}
   git:
     repo: "https://github.com/ansible/ansible.git"


### PR DESCRIPTION
When trying to use ansible from git, ansible refuse
to replace file in /usr/bin with symlink.