### PR TITLE
Add a link to to git checkout library

### DIFF
--- a/tasks/install_ansible_git.yml
+++ b/tasks/install_ansible_git.yml
@@ -41,6 +41,12 @@
   - ansible-pull
   - ansible-vault
 
+- name: Create link for library
+  file:
+    dest: /usr/local/lib/ansible
+    src:  /usr/local/src/ansible/lib/ansible
+    state: link
+
 - name: Create /etc/ansible directory
   file:
     dest: /etc/ansible


### PR DESCRIPTION
Since we use ansible module, they have to be in a place
where they can be found to be used when we use the git checkout
method.