### PR TITLE
Handle file rename in git

### DIFF
--- a/files/bastion_lib.py
+++ b/files/bastion_lib.py
@@ -48,8 +48,14 @@ def get_changed_files(git_repo, old, new):
                                     "%s..%s" % (old, new)], cwd=git_repo)
     for l in diff.split('\n'):
         if len(l) > 0:
-            (t, f) = l.split()
-            changed_files.add(f)
+            splitted = l.split()
+            if len(splitted) == 2:
+                (t, filename) = splitted
+                changed_files.add(filename)
+            elif len(splitted) == 3:
+                (t, old_filename, new_filename) = splitted
+                changed_files.add(old_filename)
+                changed_files.add(new_filename)
     return changed_files
 
 


### PR DESCRIPTION
I found out that if I rename a directory (or a file), it will
generate a line like this:

    R100    roles/example/handlers/main.yml roles/example_old/handlers/main.yml

This break with:
```
  File "/usr/local/bin/generate_ansible_command.py", line 181, in <module>
    changed_files = get_changed_files(args.git, args.old, args.new)
  File "/usr/local/lib/bastion_lib.py", line 52, in get_changed_files
    (t, f) = l.split()
  ValueError: too many values to unpack
```
So we need to verify the lenght of the array and assign values accordingly.