### PR TITLE
Add a safeguard to not run a playbook that was removed

### DIFF
--- a/files/generate_ansible_command.py
+++ b/files/generate_ansible_command.py
@@ -231,7 +231,8 @@ if update_requirements:
     commands_to_run.append('sudo /usr/local/bin/update_galaxy.sh')
 
 for p in playbooks_to_run:
-    commands_to_run.append('ansible-playbook -D %s' % p)
+    if os.path.exists(p):
+        commands_to_run.append('ansible-playbook -D %s' % p)
 
 for l in local_playbooks_to_run:
     commands_to_run.append('sudo /usr/local/bin/ansible_local.py %s' % l)


### PR DESCRIPTION
Seen in the discussion of https://github.com/OSAS/ansible-role-ansible_bastion/pull/40