### PR TITLE
Add hook to run a custom playbook when a new host is added

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,3 +205,24 @@ server.example.org.yml), it will be executed locally with a custom wrapper as ro
 the local connection plugin.
 
 The naming convention of the playbook mimic the one of ansible-pull.
+
+Adding a new host to be managed
+-------------------------------
+
+If a new host is added to the hosts file, the system will automatically try to connect
+to it to add its ssh public key to the known_hosts file. This will by default generate
+a harmess error message for the time being.
+
+If the option `run_on_new_host` is set, the playbook listed will also be run. This can
+be used to autoimatically add more ssh keys or automatically add the new server to FreeIPA.
+
+It can be used like this:
+
+```
+- hosts: bastion.example.org
+  roles:
+  - role: bastion
+    run_on_new_host:
+    - deploy_base.yml
+    - deploy_freeipa.yml
+```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,3 +33,5 @@ enable_onion_support: False
 use_tor_proxy: False
 # list of remote repository to push after a successfull run
 remotes: []
+#list of playbook to run when a new host is added
+run_on_new_host: []

--- a/files/generate_ansible_command.py
+++ b/files/generate_ansible_command.py
@@ -86,6 +86,8 @@ def load_config(config_file):
 
     if 'deploy_pattern' not in config:
         config['deploy_pattern'] = 'playbooks/deploy*.yml'
+    if 'run_on_new_host' not in config:
+        config['run_on_new_host'] = []
 
     return config
 
@@ -226,6 +228,10 @@ if 'hosts' in changed_files:
                                            "PreferredAuthentications=publickey"
                                            " -o StrictHostKeyChecking=no %s id"
                                            % (h['ssh_args'], hostname))
+
+        for p in get_playbooks_to_run(args.path):
+            if os.path.basename(p) in configuration['run_on_new_host']:
+                playbooks_to_run.add(p)
 
 if update_requirements:
     commands_to_run.append('sudo /usr/local/bin/update_galaxy.sh')

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -59,6 +59,12 @@
     src: ansible.cfg
     mode: 0755
 
+- name: Setup the bastion configuration file
+  template:
+    dest: /etc/ansible_bastion.yml
+    src: ansible_bastion.yml
+    mode: 0644
+
 - name: Create cache folder {{ cache_folder }}
   file:
     path: "{{ cache_folder }}"

--- a/templates/ansible_bastion.yml
+++ b/templates/ansible_bastion.yml
@@ -1,0 +1,6 @@
+{% if run_on_new_host|length > 0 %}
+run_on_new_host:
+{% for i in run_on_new_host %}
+- {{ i }}
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
For now, this depend on the configuration file to be set, and
we need to write code to deploy the configuration file for the
bastion, which is not written yet, and I am not sure this
would go in the main role or not.

I would favor letting people do it with a simple template or
file rather than adding a set of options. A example configuration
file should also be added later along the documentation.