### PR TITLE
Use ssh custom arguments when discovering new hosts

### DIFF
--- a/files/bastion_lib.py
+++ b/files/bastion_lib.py
@@ -89,6 +89,7 @@ def extract_list_hosts_git(revision, path):
             vars_host = variable_manager.get_vars(loader, host=host)
             result.append(
                 {'name': vars_host.get('ansible_ssh_host', host.name),
+                 'ssh_args': vars_host.get('ansible_ssh_common_args', ''),
                  'connection': vars_host.get('ansible_connection', 'ssh')})
 
     # for some reason, there is some kind of global cache that need to be

--- a/files/generate_ansible_command.py
+++ b/files/generate_ansible_command.py
@@ -222,10 +222,10 @@ if 'hosts' in changed_files:
                 # avoid using the ssh stuff on salt bus host
                 h = filter((lambda f: f['name'] == hostname), new)[0]
                 if h['connection'] == 'ssh':
-                    commands_to_run.append("ssh -o "
+                    commands_to_run.append("ssh %s -o "
                                            "PreferredAuthentications=publickey"
                                            " -o StrictHostKeyChecking=no %s id"
-                                           % hostname)
+                                           % (h['ssh_args'], hostname))
 
 if update_requirements:
     commands_to_run.append('sudo /usr/local/bin/update_galaxy.sh')


### PR DESCRIPTION
Since gluster use a few servers beyond a bastion, it
was found that our automated discovery of the ssh key, done
by connecting to the remote server, do not take in account
custom ansible_ssh_common_args. So we just take the arguments
and add them to the command.