### PR TITLE
Use a less heavyweight method to force color

### DIFF
--- a/templates/ansible.cfg
+++ b/templates/ansible.cfg
@@ -29,7 +29,6 @@ transport      = smart
 remote_port    = 22
 module_lang    = C
 
-force_color    = True
 retry_files_enabled = False
 
 stdout_callback = actionable

--- a/templates/cmd_config.sudoers
+++ b/templates/cmd_config.sudoers
@@ -7,6 +7,7 @@ Defaults!UPDATE_ANSIBLE_CONFIG    !requiretty
 
 Cmnd_Alias GENERATE_ANSIBLE_COMMAND = /usr/local/bin/generate_ansible_command.py
 Defaults!GENERATE_ANSIBLE_COMMAND !requiretty
+Defaults!GENERATE_ANSIBLE_COMMAND env_keep=ANSIBLE_FORCE_COLOR
 
 %{{ ansible_committers_group }}  ALL=(root) NOPASSWD: UPDATE_ANSIBLE_CONFIG, UPDATE_EXTERNAL_ROLES
 %{{ ansible_committers_group }}  ALL=({{ ansible_username }}) NOPASSWD: GENERATE_ANSIBLE_COMMAND

--- a/templates/hooks/trigger_run.sh
+++ b/templates/hooks/trigger_run.sh
@@ -27,5 +27,5 @@ echo "* Triggering a run of ansible"
 while read OLDREV NEWREV REF
 do
         # run ansible
-        sudo -n -u {{ ansible_username }} /usr/local/bin/generate_ansible_command.py {{ '--compat' if not compat_disable else '' }} --old $OLDREV --new $NEWREV --git $(pwd)
+        sudo -n -u {{ ansible_username }} ANSIBLE_FORCE_COLOR=1 /usr/local/bin/generate_ansible_command.py {{ '--compat' if not compat_disable else '' }} --old $OLDREV --new $NEWREV --git $(pwd)
 done


### PR DESCRIPTION
force_color = True was added to make sure the colors
are displayed by git post commit hooks. However, one
unplanned side effect is that colors are also displayed
in mail sent by cron, thuis making them hard to read.

So instead of forcing for all runs, we should make
that only for the sudo runs.