### PR TITLE
Add a wrapper to be able to remove/clean ssh public keys

### DIFF
--- a/files/clean_public_ssh_keys.py
+++ b/files/clean_public_ssh_keys.py
@@ -1,0 +1,49 @@
+#!/usr/bin/python
+#
+# Copyright (c) 2017 Michael Scherer <mscherer@redhat.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+import sys
+import re
+import subprocess
+
+if len(sys.argv) != 1:
+    print "Usage: clean_public_ssh_keys.py hostname"
+    print "Remove the hostname from .ssh/known_hosts"
+    sys.exit(1)
+
+target = sys.argv[1]
+
+# use a minimal verification on the argument, since we already verify
+# with ssh-keygen after.
+if not re.match('^[\w.]+$', target):
+    print "Invalid hostname %s" % target
+    sys.exit(1)
+
+if subprocess.call(['ssh-keygen', '-F', target]) != 0:
+    print "Nothing to clean for %s" % target
+    sys.exit(0)
+
+if subprocess.call(['ssh-keygen', '-R', target]) != 0:
+    print "Error when cleaning %s" % target
+    sys.exit(1)
+
+print "SSH public key got cleaned for %s" % target

--- a/tasks/git_shell.yml
+++ b/tasks/git_shell.yml
@@ -23,6 +23,14 @@
   - help
   - update_external_roles
 
+- name: Copy templated command in the git-shell-commands directory
+  template:
+    dest: "{{ git_home }}/git-shell-commands/{{ item }}"
+    src: "{{ item }}"
+    mode: "0755"
+  with_items:
+  - clean_ssh_public_keys
+
 - name: Link repositories in the home
   file:
     state: link

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -106,6 +106,7 @@
   - update_galaxy.sh
   - update_ansible_config.sh
   - ansible_local.py
+  - clean_public_ssh_keys.py
 
 - name: Deploy the library of function for bastion
   copy:

--- a/templates/clean_ssh_public_keys
+++ b/templates/clean_ssh_public_keys
@@ -1,0 +1,29 @@
+#!/bin/sh
+#
+# {{ ansible_managed }}
+#
+# Copyright (c) 2017 Michael Scherer <mscherer@redhat.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+# this is just a wrapper to run a python script to remove ssh keys from .ssh/know_hosts
+
+TARGET=$1
+sudo -n -u {{ ansible_username }} /usr/local/bin/clean_ssh_public_keys.py "$TARGET"

--- a/templates/cmd_config.sudoers
+++ b/templates/cmd_config.sudoers
@@ -8,8 +8,11 @@ Defaults!UPDATE_ANSIBLE_CONFIG    !requiretty
 Cmnd_Alias GENERATE_ANSIBLE_COMMAND = /usr/local/bin/generate_ansible_command.py
 Defaults!GENERATE_ANSIBLE_COMMAND !requiretty
 
+Cmnd_Alias CLEAN_SSH_PUBLIC_KEYS = /usr/local/bin/clean_ssh_public_keys.py
+Defaults!CLEAN_SSH_PUBLIC_KEYS !requiretty
+
 %{{ ansible_committers_group }}  ALL=(root) NOPASSWD: UPDATE_ANSIBLE_CONFIG, UPDATE_EXTERNAL_ROLES
-%{{ ansible_committers_group }}  ALL=({{ ansible_username }}) NOPASSWD: GENERATE_ANSIBLE_COMMAND
+%{{ ansible_committers_group }}  ALL=({{ ansible_username }}) NOPASSWD: GENERATE_ANSIBLE_COMMAND, CLEAN_SSH_PUBLIC_KEYS
 
 {% if ansible_admins_group is defined %}
 Cmnd_Alias ANSIBLE_COMMAND = /usr/bin/ansible,/usr/bin/ansible-playbook


### PR DESCRIPTION
This is useful in case a server got reinstalled, and while
this can be done manually, the long term goal is to avoid the need
to be root (or using su to change username) for anything.