### PR TITLE
Silence "ansible-galaxy install" cronjob

### DIFF
--- a/files/update_galaxy.sh
+++ b/files/update_galaxy.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 [ -w /etc/ansible/roles ] || (echo "Cannot write /etc/ansible/roles, aborting"; exit 1)
 cd /etc/ansible
-/usr/bin/ansible-galaxy install -f -r /etc/ansible/requirements.yml
+/usr/bin/ansible-galaxy install -f -r /etc/ansible/requirements.yml >/dev/null


### PR DESCRIPTION
There is no -q option or anything, so we have to use a shell
redirection for now (and adding -q is non trivial)