### PR TITLE
Use ansible ping

### DIFF
--- a/files/bastion_lib.py
+++ b/files/bastion_lib.py
@@ -125,9 +125,7 @@ def extract_list_hosts_git(revision, path):
         for host in inventory.get_hosts(group):
             vars_host = variable_manager.get_vars(loader, host=host)
             result.append(
-                {'name': vars_host.get('ansible_ssh_host', host.name),
-                 'ssh_args': vars_host.get('ansible_ssh_common_args', ''),
-                 'connection': vars_host.get('ansible_connection', 'ssh')})
+                {'name': vars_host.get('ansible_ssh_host', host.name)})
 
     # for some reason, there is some kind of global cache that need to be
     # cleaned

--- a/files/generate_ansible_command.py
+++ b/files/generate_ansible_command.py
@@ -231,13 +231,11 @@ if 'hosts' in changed_files:
             # No need for a full fledged verification, just making
             # sure there is no funky chars for shell, and no space
             if re.search('^[\\w.-]+$', hostname):
-                # avoid using the ssh stuff on salt bus host
-                h = filter((lambda f: f['name'] == hostname), new)[0]
-                if h['connection'] == 'ssh':
-                    commands_to_run.append(["ssh", h['ssh_args'], "-o",
-                                           "PreferredAuthentications=publickey",
-                                           "-o", "StrictHostKeyChecking=no",
-                                           hostname, "id"])
+                commands_to_run.append({'cmd': ["ansible", "-m", "ping",
+                                        "-l", hostname, "all"],
+                                        'env':
+                                        {"ANSIBLE_HOST_KEY_CHECKING":
+                                         "false"}})
 
         for p in get_playbooks_to_run(args.path):
             if os.path.basename(p) in configuration['run_on_new_host']:


### PR DESCRIPTION
This PR implement a cleaner system for adding the ssh key for TOFU. By using ansible ping, we directly benefit from the parsing of all configuration file done by ansible, which will permit later to refactor and remove the code (once this one have been exercised enough)