### PR TITLE
Fix bug trigger when there is a empty configuration file

### DIFF
--- a/files/generate_ansible_command.py
+++ b/files/generate_ansible_command.py
@@ -80,9 +80,13 @@ else:
 
 
 def load_config(config_file):
-    config = {}
+    config = None
     if os.path.isfile(config_file):
         config = yaml.safe_load(open(config_file, 'r'))
+    # keep this conditional, since yaml.safe_load return None
+    # for a empty file
+    if config is None:
+        config = {}
 
     if 'deploy_pattern' not in config:
         config['deploy_pattern'] = 'playbooks/deploy*.yml'


### PR DESCRIPTION
Attempting to push trigger a error:

    Traceback (most recent call last):
      File "/usr/local/bin/generate_ansible_command.py", line 95, in <module>
        configuration = load_config(args.config)
      File "/usr/local/bin/generate_ansible_command.py", line 87, in load_config
        if 'deploy_pattern' not in config:
    TypeError: argument of type 'NoneType' is not iterable

It turn out that yaml.safe_load return None when the file is empty,
and we do not handle this at all.