### PR TITLE
Fix location of checkout for roles installation

### DIFF
--- a/files/update_galaxy.sh
+++ b/files/update_galaxy.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 [ -w /etc/ansible/roles ] || (echo "Cannot write /etc/ansible/roles, aborting"; exit 1)
 cd /etc/ansible
-/usr/bin/ansible-galaxy install -f -r /etc/ansible/requirements.yml >/dev/null
+/usr/bin/ansible-galaxy install -f -r /etc/ansible/requirements.yml -p /etc/ansible/roles >/dev/null


### PR DESCRIPTION
In 2.3, the default location of installation got changed and
it now go to /root/.ansible/ since 37cef2a9.

While I think this might have to be changed, in the mean time, it
is better to be explicite in case this is not changed before the
release.