### PR TITLE
Fix the callback

### DIFF
--- a/files/callback/lock_run.py
+++ b/files/callback/lock_run.py
@@ -37,7 +37,7 @@ class CallbackModule(CallbackBase):
     def __init__(self):
         super(CallbackModule, self).__init__()
 
-    def v2_playbook_on_play_start(self, play):
+    def v2_playbook_on_start(self, playbook):
         lock_file = os.path.expanduser('{}/ansible_run_lock'.format(
             os.environ.get('XDG_RUNTIME_DIR', '~')))
         if os.path.exists(lock_file):


### PR DESCRIPTION
I just found out that a playbook with more than 1 play would not
run, because the lock is verified for each play rather than each file.

So using the right callback is better.