### PR TITLE
Fix potential code execution due to VariableManager plugin loading

### DIFF
--- a/files/bastion_lib.py
+++ b/files/bastion_lib.py
@@ -29,6 +29,7 @@ from ansible.parsing.dataloader import DataLoader
 import subprocess
 import tempfile
 import socket
+import shutil
 import os
 from sets import Set
 
@@ -74,7 +75,8 @@ def extract_list_hosts_git(revision, path):
         return result
 
     # beware, not portable on windows
-    tmp_file = tempfile.NamedTemporaryFile('w+')
+    tmp_dir = tempfile.mkdtemp()
+    tmp_file = tempfile.NamedTemporaryFile('w+', dir=tmp_dir)
     tmp_file.write(host_content)
     tmp_file.flush()
     os.fsync(tmp_file.fileno())
@@ -95,6 +97,8 @@ def extract_list_hosts_git(revision, path):
     # for some reason, there is some kind of global cache that need to be
     # cleaned
     inventory.refresh_inventory()
+    shutil.rmtree(tmp_dir)
+
     return result
 
 


### PR DESCRIPTION
While investigating a problem on the code, I found out that ansible
do load plugin from the directory where the hosts file is when
we use VariableManager.

So since the file used is stored in /tmp, this mean that ansible
will try to load plugins from /tmp/vars_plugin, resulting in potential
code execution as a different user when triggering a git commit.

This would matter only in very specific setup (since there is already
easier path to deploy source code, that's the whole point of the role
itself), and requires a existing user to have access to /tmp, hence to the
server.

One role that can be used to mitigate this and later /tmp issue is
https://github.com/OSAS/ansible-role-polyinst_tmp