### PR TITLE
Use shlex to handle ssh argument with double quotes

### DIFF
--- a/files/generate_ansible_command.py
+++ b/files/generate_ansible_command.py
@@ -48,6 +48,7 @@ import fnmatch
 import syslog
 import sys
 import argparse
+import shlex
 
 # custom library
 sys.path.append('/usr/local/lib')
@@ -252,4 +253,4 @@ for c in commands_to_run:
         print c
     else:
         syslog.syslog("Running {}".format(c))
-        subprocess.call(c.split(), cwd=args.path)
+        subprocess.call(shlex.split(c), cwd=args.path)


### PR DESCRIPTION
While adding new server on gluster infra, I stumbled on the following
error message:

    Bad stdio forwarding specification '%h:%p'

After some debugging, it was caused by the following piece of code:

    >>> c='ssh -o ProxyCommand="ssh -q -W %h:%p root@myrmicinae.rht.gluster.org" -o PreferredAuthentications=publickey -o StrictHostKeyChecking=no builder6.int.rht.gluster.org id'
    >>> c.split()
    ['ssh', '-o', 'ProxyCommand="ssh', '-q', '-W', '%h:%p', 'root@myrmicinae.rht.gluster.org"', '-o', 'PreferredAuthentications=publickey', '-o', 'StrictHostKeyChecking=no', 'builder6.int.rht.gluster.org', 'id']
    >>> subprocess.call(c.split())
    Bad stdio forwarding specification '%h:%p'

It seems that subprocess.call need to have a string splitted like the shell,
hence the use of shlex.split()