### PR TITLE
Fix the OSError exception seen since a few days

### DIFF
--- a/files/bastion_lib.py
+++ b/files/bastion_lib.py
@@ -97,6 +97,14 @@ def extract_list_hosts_git(revision, path):
     # for some reason, there is some kind of global cache that need to be
     # cleaned
     inventory.refresh_inventory()
+    # we need to del the temporary file before the directory, or a exception
+    # is launched and ignored:
+    #   Exception OSError: (2, 'No such file or directory',
+    #   '/tmp/tmpw2IQjN/tmppHjNDO') #   in <bound method
+    #   _TemporaryFileWrapper.__del__ of <closed file '<fdopen>',
+    #   mode 'w+' at 0x2cfd6f0>> ignored
+    #
+    del tmp_file
     shutil.rmtree(tmp_dir)
 
     return result


### PR DESCRIPTION
When adding a new hosts, a error message do appear:

    Exception OSError: (2, 'No such file or directory', '/tmp/tmp7Cq_Us/tmpxXIavL') in <bound method _TemporaryFileWrapper.__del__ of <closed file '<fdopen>', mode 'w+' at 0x2cfd6f0>> ignored

It turn out to be caused by a mismatch of the object lifecycle. When tmp_file
is out of scope, it get erased, but the file is erased before by the rmtree
function, hence the exception. While this doesn't affect functionnality, this
is a bit ugly and misleading, so better fix it.