### PR TITLE
Remove deprecated configuration

### DIFF
--- a/templates/ansible.cfg
+++ b/templates/ansible.cfg
@@ -22,7 +22,6 @@ remote_tmp     = $HOME/.ansible/tmp
 pattern        = *
 forks          = 5
 poll_interval  = 15
-sudo_user      = root
 #ask_sudo_pass = True
 #ask_pass      = True
 transport      = smart
@@ -47,8 +46,6 @@ gathering = implicit
 # uncomment this to disable SSH key host checking
 #host_key_checking = False
 
-# change this for alternative sudo implementations
-sudo_exe = sudo
 
 # what flags to pass to sudo
 #sudo_flags = -H
@@ -184,18 +181,4 @@ filter_plugins     = /usr/share/ansible_plugins/filter_plugins
 # (default is sftp)
 #scp_if_ssh = True
 
-[accelerate]
-accelerate_port = 5099
-accelerate_timeout = 30
-accelerate_connect_timeout = 5.0
-
-# The daemon timeout is measured in minutes. This time is measured
-# from the last activity to the accelerate daemon.
-accelerate_daemon_timeout = 30 
-
-# If set to yes, accelerate_multi_key will allow multiple
-# private keys to be uploaded to it, though each user must
-# have access to the system via SSH to add a new key. The default
-# is "no".
-#accelerate_multi_key = yes
 


### PR DESCRIPTION
Since 2.4, Ansible complain loudly about them, so I have to remove them.
They are all leftover from the time we did import the configuration and
shouldn't matter much.