### PR TITLE
Fix backtrace when the playbook is empty

### DIFF
--- a/files/generate_ansible_command.py
+++ b/files/generate_ansible_command.py
@@ -109,6 +109,9 @@ def parse_roles_playbook(playbook_file):
     playbook = yaml.load(open(playbook_file, 'r'))
     result = {}
 
+    if playbook is None:
+        return result
+
     for doc in playbook:
         host = doc['hosts']
         roles = Set()


### PR DESCRIPTION
While commenting a playbook on gluster.org, I have hit a backtrace
because the yaml document is empty.

    Traceback (most recent call last):
      File "/usr/local/bin/generate_ansible_command.py", line 207, in <module>
        if len(get_hosts_for_role(splitted_path[1], p)) > 0:
      File "/usr/local/bin/generate_ansible_command.py", line 174, in get_hosts_for_role
        host_roles = get_host_roles_dict(playbook_file)
      File "/usr/local/bin/generate_ansible_command.py", line 159, in get_host_roles_dict
        hosts = parse_roles_playbook(playbook_file)
      File "/usr/local/bin/generate_ansible_command.py", line 112, in parse_roles_playbook
        for doc in playbook:
    TypeError: 'NoneType' object is not iterable