### PR TITLE
Use the new configuration for inventory file

### DIFF
--- a/templates/ansible.cfg
+++ b/templates/ansible.cfg
@@ -16,7 +16,7 @@ fact_caching = jsonfile
 fact_caching_connection = {{ cache_folder }}
 # some basic default values...
 
-hostfile       = /etc/ansible/hosts
+inventory      = /etc/ansible/hosts
 library        = /usr/share/ansible
 remote_tmp     = $HOME/.ansible/tmp
 pattern        = *


### PR DESCRIPTION
hostfile is deprecated since a while, and ansible keep warning
about it