### PR TITLE
Add a timeout of 1h on the run

### DIFF
--- a/files/ansible_run_all.sh
+++ b/files/ansible_run_all.sh
@@ -24,6 +24,6 @@ cd /etc/ansible
 
 for i in playbooks/deploy*.yml; do 
     logger "Started run of $i in ansible_run_all.sh"
-    ansible-playbook -D $i $*
+    timeout 1h ansible-playbook -D $i $*
     logger "Finished run of $i in ansible_run_all.sh"
 done


### PR DESCRIPTION
I stumbled today on a blocked playbook running since a while.
This prevented certificate renewal with LE, so not great.