### PR TITLE
Do not assume that a playbook has 1 hosts entry

### DIFF
--- a/files/generate_ansible_command.py
+++ b/files/generate_ansible_command.py
@@ -127,7 +127,10 @@ def parse_roles_playbook(playbook_file):
         roles = Set()
         for r in doc.get('roles', []):
             roles.add(get_role(r))
-        result[host] = roles
+        if host in result:
+            result[host] = result[host].union(roles)
+        else:
+            result[host] = roles
     cache_role_playbook[playbook_file] = result
     return result
 


### PR DESCRIPTION
For gluster, we have one playbook with multiple hosts in the play,
but using the same group:
```
  ---
  - hosts: servers
    roles:
    - role: example-client
  - hosts: servers
    roles:
    - role: example-server
      hostname: myrtille.example.org
```
Current code erase the roles defined in the 1st declaration as
this is overwritten by the last one.